### PR TITLE
Functionality for existing +> operator

### DIFF
--- a/src/main/antlr4/se/kth/mal/sLang.g4
+++ b/src/main/antlr4/se/kth/mal/sLang.g4
@@ -85,8 +85,8 @@ children
 
 // -> indicates that the generalization attack step definition is replaced by the specialization, while +> denotes the specialization is appended
 childOperator
-	:	'->'
-	|	'+>'
+	:	'->' #childReplacement
+	|	'+>' #childExtension
 	;
 
 // An attack step can have sub-attack-steps only to better organize the code.

--- a/src/main/java/com/foreseeti/generator/SecuriCADCodeGenerator.java
+++ b/src/main/java/com/foreseeti/generator/SecuriCADCodeGenerator.java
@@ -818,7 +818,7 @@ public class SecuriCADCodeGenerator {
 
          writer.println("@Override");
          writer.println("public Set<AttackStep> getAttackStepChildren() {");
-         if (!attackStep.isSpecialization()) {
+         if (!attackStep.isSpecialization() || attackStep.isExtension) {
             writer.println("Set<AttackStep> set = new HashSet<>(super.getAttackStepChildren());");
          }
          else {

--- a/src/main/java/se/kth/mal/AttackStep.java
+++ b/src/main/java/se/kth/mal/AttackStep.java
@@ -10,6 +10,7 @@ import se.kth.mal.steps.Step;
 public class AttackStep {
    public List<Step>          steps                     = new ArrayList<>();
    public List<Step>          parentSteps               = new ArrayList<>();
+   public boolean             isExtension               = false;
    boolean                    isSpecialization;
    String                     superAttackStepName       = "";
    Boolean                    hasSpecialization         = false;

--- a/src/main/java/se/kth/mal/CompilerWriter.java
+++ b/src/main/java/se/kth/mal/CompilerWriter.java
@@ -495,6 +495,9 @@ public class CompilerWriter {
       if (!attackStep.steps.isEmpty()) {
          writer.println("@Override");
          writer.println("public void updateChildren(Set<AttackStep> activeAttackSteps) {");
+         if (attackStep.isExtension) {
+            writer.println("super.updateChildren(activeAttackSteps);");
+         }
          for (Step step : attackStep.steps) {
             step.print(writer, "%s.updateTtc(this, ttc, activeAttackSteps);\n");
          }

--- a/src/main/java/se/kth/mal/SecuriLangListener.java
+++ b/src/main/java/se/kth/mal/SecuriLangListener.java
@@ -3,6 +3,7 @@ package se.kth.mal;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 import se.kth.mal.sLangParser.CategoryDeclarationContext;
+import se.kth.mal.sLangParser.ChildExtensionContext;
 import se.kth.mal.sLangParser.ExpressionChildContext;
 import se.kth.mal.sLangParser.ExpressionStepContext;
 import se.kth.mal.sLangParser.ImmediateContext;
@@ -56,6 +57,11 @@ public class SecuriLangListener extends sLangBaseListener {
    public void enterAssociationDeclaration(sLangParser.AssociationDeclarationContext ctx) {
       model.addAssociation(ctx.Identifier(0).getText(), ctx.Identifier(1).getText(), ctx.multiplicity(0).getText(), ctx.leftRelation().getText(), ctx.Identifier(2).getText(),
             ctx.rightRelation().getText(), ctx.multiplicity(1).getText(), ctx.Identifier(3).getText(), ctx.Identifier(4).getText());
+   }
+
+   @Override
+   public void enterChildExtension(ChildExtensionContext ctx) {
+      attackStep.isExtension = true;
    }
 
    @Override


### PR DESCRIPTION
The +> operator existed but no functionality was implemented. This allows an attack step to extends its parent instead of override it.