### PR TITLE
Transitive operator, set operation shortening and variables

### DIFF
--- a/src/main/antlr4/se/kth/mal/sLang.g4
+++ b/src/main/antlr4/se/kth/mal/sLang.g4
@@ -151,11 +151,11 @@ attackStepType
 expression
     :   Identifier #immediate
     |   (expressionStep '.' )+ Identifier #normal
-    |	setOperation '.' Identifier #select
+    |   setOperation '.' Identifier #select
     ;
 
 setOperation
-	:	'(' setChild (setOperator setChild)+ ')' ('[' Identifier ']')? ('.' expressionStep)*
+	:	(preExpressionStep '.' )* '(' setChild (setOperator setChild)+ ')' ('[' Identifier ']')? ('.' expressionStep)*
 	;
     
 setOperator
@@ -172,6 +172,12 @@ setChild
 expressionStep
     :   Identifier ('[' Identifier ']')?
     ;
+
+// Straight up copy, we need to differentiate steps before and after parenthesis but still be in the same parse-step
+preExpressionStep
+    :   Identifier ('[' Identifier ']')?
+    ;
+
 Identifier
     :   JavaLetter JavaLetterOrDigit*
 	;

--- a/src/main/antlr4/se/kth/mal/sLang.g4
+++ b/src/main/antlr4/se/kth/mal/sLang.g4
@@ -151,22 +151,27 @@ attackStepType
 expression
     :   Identifier #immediate
     |   (expressionStep '.' )+ Identifier #normal
-    |  '(' expressionChild (setOperator expressionChild)+ ')' ('[' Identifier ']')? ('.' expressionStep)* '.' Identifier #select
+    |	setOperation '.' Identifier #select
     ;
 
-expressionStep
-    :   Identifier ('[' Identifier ']')?
-    ;
-
-expressionChild
-    :   expressionStep ('.' expressionStep)*
-    ;
+setOperation
+	:	'(' setChild (setOperator setChild)+ ')' ('[' Identifier ']')? ('.' expressionStep)*
+	;
     
 setOperator
     :   '/\\'
     |   '\\/'
     ;
+	
 
+setChild
+	:	expressionStep ('.' expressionStep)*
+	|	setOperation
+	;
+
+expressionStep
+    :   Identifier ('[' Identifier ']')?
+    ;
 Identifier
     :   JavaLetter JavaLetterOrDigit*
 	;

--- a/src/main/antlr4/se/kth/mal/sLang.g4
+++ b/src/main/antlr4/se/kth/mal/sLang.g4
@@ -178,15 +178,6 @@ setOperator
     |   '\\/'
     ;
 
-expressionStep
-    :   Identifier ('[' Identifier ']')?
-    ;
-
-// Straight up copy, we need to differentiate steps before and after parenthesis but still be in the same parse-step
-preExpressionStep
-    :   Identifier ('[' Identifier ']')?
-    ;
-
 Identifier
     :   JavaLetter JavaLetterOrDigit*
 	;

--- a/src/main/antlr4/se/kth/mal/sLang.g4
+++ b/src/main/antlr4/se/kth/mal/sLang.g4
@@ -149,33 +149,34 @@ attackStepType
 	;
 
 expression
-    :   Identifier #immediate
-    |   (expressionStep '.' )+ Identifier #normal
-    |   setOperation '.' Identifier #select
+    :   (expressionSteps '.')? Identifier
+    ;
+    
+expressionSteps
+    :   expressionStep ('.' expressionStep)*
     ;
 
 expressionStep
-    :   Identifier ('[' Identifier ']')? transitiveOperator?
+    :   normalStep
+    |   setStep
     ;
 
-transitiveOperator
-	:	'+'
-	;
-
-expressionChild
-    :   expressionStep ('.' expressionStep)*
+normalStep
+    :   Identifier ('[' Identifier ']')? transitiveSign?
     ;
-    
+
+transitiveSign
+    :   '+'
+    ;
+
+setStep
+    :   '(' expressionSteps (setOperator expressionSteps)+ ')' ('[' Identifier ']')?
+    ;
+
 setOperator
     :   '/\\'
     |   '\\/'
     ;
-	
-
-setChild
-	:	expressionStep ('.' expressionStep)*
-	|	setOperation
-	;
 
 expressionStep
     :   Identifier ('[' Identifier ']')?

--- a/src/main/antlr4/se/kth/mal/sLang.g4
+++ b/src/main/antlr4/se/kth/mal/sLang.g4
@@ -154,9 +154,17 @@ expression
     |   setOperation '.' Identifier #select
     ;
 
-setOperation
-	:	(preExpressionStep '.' )* '(' setChild (setOperator setChild)+ ')' ('[' Identifier ']')? ('.' expressionStep)*
+expressionStep
+    :   Identifier ('[' Identifier ']')? transitiveOperator?
+    ;
+
+transitiveOperator
+	:	'+'
 	;
+
+expressionChild
+    :   expressionStep ('.' expressionStep)*
+    ;
     
 setOperator
     :   '/\\'

--- a/src/main/java/se/kth/mal/CompilerModel.java
+++ b/src/main/java/se/kth/mal/CompilerModel.java
@@ -78,7 +78,7 @@ public class CompilerModel {
 
       // TODO: Not really happy with this
       Pattern stepPattern = Pattern.compile("[^-][-+]>([^\\}|&]+)", Pattern.CASE_INSENSITIVE);
-      Pattern varPattern = Pattern.compile("let\\s+([a-z]+)\\s*=\\s*([^,]+),", Pattern.CASE_INSENSITIVE);
+      Pattern varPattern = Pattern.compile("let\\s+([a-z0-9_]+)\\s*=\\s*([^,]+),", Pattern.CASE_INSENSITIVE);
 
       String master = "";
 
@@ -95,7 +95,9 @@ public class CompilerModel {
             String content = var.group(2);
             System.out.printf("var '%s' content '%s'\n", name, content);
             text = text.substring(0, var.start()) + text.substring(var.end(), text.length());
-            text = text.replace(name, content);
+            // Escape both pattern and replacement. Make sure we only find
+            // occurances that are not contained words.
+            text = text.replaceAll("([^a-z0-9_])" + Pattern.quote(name) + "([^a-z0-9_])", "$1" + Matcher.quoteReplacement(content) + "$2");
             var = varPattern.matcher(text);
          }
          master += text;

--- a/src/main/java/se/kth/mal/CompilerModel.java
+++ b/src/main/java/se/kth/mal/CompilerModel.java
@@ -76,7 +76,6 @@ public class CompilerModel {
       // attack steps before antlr goes to work and perform a simple string
       // replace.
 
-      // TODO: Not really happy with this
       Pattern stepPattern = Pattern.compile("[^-][-+]>([^\\}|&]+)", Pattern.CASE_INSENSITIVE);
       Pattern varPattern = Pattern.compile("let\\s+([a-z0-9_]+)\\s*=\\s*([^,]+),", Pattern.CASE_INSENSITIVE);
 

--- a/src/main/java/se/kth/mal/CompilerModel.java
+++ b/src/main/java/se/kth/mal/CompilerModel.java
@@ -95,7 +95,7 @@ public class CompilerModel {
             String content = var.group(2);
             System.out.printf("var '%s' content '%s'\n", name, content);
             text = text.substring(0, var.start()) + text.substring(var.end(), text.length());
-            text = text.replaceAll(name, content);
+            text = text.replace(name, content);
             var = varPattern.matcher(text);
          }
          master += text;

--- a/src/main/java/se/kth/mal/CompilerModel.java
+++ b/src/main/java/se/kth/mal/CompilerModel.java
@@ -356,9 +356,6 @@ public class CompilerModel {
             for (Step step : attackStep.steps) {
                updateStep(step);
                Step parent = step.reverse(step.getTargetAsset());
-               System.err.print("Reversing, ");
-               step.debug.print();
-               System.err.println(parent.illustrate());
                getAsset(step.getTargetAsset()).getAttackStep(step.to).parentSteps.add(parent);
             }
          }

--- a/src/main/java/se/kth/mal/CompilerModel.java
+++ b/src/main/java/se/kth/mal/CompilerModel.java
@@ -220,6 +220,10 @@ public class CompilerModel {
    }
 
    public Association getConnectedAssociation(String leftAssetName, String rightRoleName) {
+      return getConnectedAssociation(leftAssetName, rightRoleName, null);
+   }
+
+   public Association getConnectedAssociation(String leftAssetName, String rightRoleName, Connection connection) {
       for (Association association : this.associations) {
          if (association.leftAssetName.equals(leftAssetName) && association.rightRoleName.equals(rightRoleName)) {
             return association;
@@ -233,9 +237,11 @@ public class CompilerModel {
       if (!leftAsset.superAssetName.isEmpty()) {
          System.out.println(String.format("No association from asset '%s' to field [%s]", leftAssetName, rightRoleName));
          System.out.println(String.format("  Checking extended parent '%s' to field [%s]", leftAsset.superAssetName, rightRoleName));
-         return getConnectedAssociation(leftAsset.superAssetName, rightRoleName);
+         return getConnectedAssociation(leftAsset.superAssetName, rightRoleName, connection);
       }
-
+      if (connection != null) {
+         connection.debug.print();
+      }
       throw new Error(String.format("No association from asset '%s' to field [%s]", leftAssetName, rightRoleName));
    }
 
@@ -301,7 +307,7 @@ public class CompilerModel {
          if (!(connection instanceof SelectConnection)) {
             // Normal step
             System.out.println(connection.field);
-            Association association = getConnectedAssociation(connection.previousAsset, connection.field);
+            Association association = getConnectedAssociation(connection.previousAsset, connection.field, connection);
             boolean previousAssetLeft = isLeftAsset(association, connection.previousAsset);
             connection.associationUpdate(association, previousAssetLeft);
          }
@@ -319,7 +325,9 @@ public class CompilerModel {
                   asset = child.getTargetAsset();
                }
                else if (!child.getTargetAsset().equals(asset)) {
-                  throw new Error(String.format("Different set type on index %d; %s =/= %s", i, child.getTargetAsset(), asset));
+                  ((SelectConnection) connection).debug.print();
+                  child.debug.print();
+                  throw new Error(String.format("Different set type; %s =/= %s", child.getTargetAsset(), asset));
                }
             }
             ((SelectConnection) connection).update();

--- a/src/main/java/se/kth/mal/CompilerModel.java
+++ b/src/main/java/se/kth/mal/CompilerModel.java
@@ -279,6 +279,7 @@ public class CompilerModel {
     *           Step to be updated.
     */
    void updateStep(Step step) {
+      System.out.println("Updating step, " + step);
       for (Connection connection : step.connections) {
          if (connection instanceof SelectConnection) {
             for (Step childStep : ((SelectConnection) connection).steps) {
@@ -294,6 +295,7 @@ public class CompilerModel {
             ((SelectConnection) connection).update();
          }
          else {
+            System.out.println("prev: " + connection.previousAsset + ", to field " + connection.field);
             Association association = getConnectedAssociation(connection.previousAsset, connection.field);
             boolean previousAssetLeft = isLeftAsset(association, connection.previousAsset);
             connection.associationUpdate(association, previousAssetLeft);
@@ -303,6 +305,7 @@ public class CompilerModel {
             step.connections.get(nextIndex).previousAsset = connection.getCastedAsset();
          }
       }
+      System.out.println("Done updating step, " + step.from + ", " + step.to);
    }
 
    public void update() {

--- a/src/main/java/se/kth/mal/CompilerModel.java
+++ b/src/main/java/se/kth/mal/CompilerModel.java
@@ -356,6 +356,9 @@ public class CompilerModel {
             for (Step step : attackStep.steps) {
                updateStep(step);
                Step parent = step.reverse(step.getTargetAsset());
+               System.err.print("Reversing, ");
+               step.debug.print();
+               System.err.println(parent.illustrate());
                getAsset(step.getTargetAsset()).getAttackStep(step.to).parentSteps.add(parent);
             }
          }

--- a/src/main/java/se/kth/mal/SecuriLangListener.java
+++ b/src/main/java/se/kth/mal/SecuriLangListener.java
@@ -16,6 +16,7 @@ import se.kth.mal.sLangParser.SetChildContext;
 import se.kth.mal.sLangParser.SetOperationContext;
 import se.kth.mal.sLangParser.SetOperatorContext;
 import se.kth.mal.steps.Connection;
+import se.kth.mal.steps.RecursiveConnection;
 import se.kth.mal.steps.SelectConnection;
 import se.kth.mal.steps.Step;
 

--- a/src/main/java/se/kth/mal/SecuriLangListener.java
+++ b/src/main/java/se/kth/mal/SecuriLangListener.java
@@ -188,12 +188,17 @@ public class SecuriLangListener extends sLangBaseListener {
    public void enterExpression(ExpressionContext ctx) {
       String reachedStep = ctx.Identifier().getText();
       Step currentStep = new Step(asset.name, attackStep.name, reachedStep);
-      inPrint("New path from '%s$%s' through '%s' reaching '%s'", asset.name, attackStep.name, ctx.expressionSteps().getText(), reachedStep);
-      level++;
-      for (ExpressionStepContext step : ctx.expressionSteps().expressionStep()) {
-         currentStep.connections.add(parseStep(step));
+      if (ctx.expressionSteps() != null) {
+         inPrint("New path from '%s$%s' through '%s' reaching '%s'", asset.name, attackStep.name, ctx.expressionSteps().getText(), reachedStep);
+         level++;
+         for (ExpressionStepContext step : ctx.expressionSteps().expressionStep()) {
+            currentStep.connections.add(parseStep(step));
+         }
+         level--;
       }
-      level--;
+      else {
+         inPrint("New path from '%s$%s' to self reaching '%s'", asset.name, attackStep.name, reachedStep);
+      }
       currentStep.debug = debug(ctx);
       attackStep.steps.add(currentStep);
    }

--- a/src/main/java/se/kth/mal/steps/Connection.java
+++ b/src/main/java/se/kth/mal/steps/Connection.java
@@ -143,4 +143,8 @@ public class Connection {
 
       return prefix;
    }
+
+   public String illustrate() {
+      return field;
+   }
 }

--- a/src/main/java/se/kth/mal/steps/Connection.java
+++ b/src/main/java/se/kth/mal/steps/Connection.java
@@ -15,21 +15,27 @@ import se.kth.mal.Association;
  * made to traverse back and forth in the links.
  */
 public class Connection {
-   public String previousAsset        = ""; // Previous asset according to the
-                                            // association
-   public String previousCast         = ""; // What the previous asset must be
-                                            // cast as to be valid. Used
-                                            // whenever an asset extends some
-                                            // other asset, but the association
-                                            // is made with the parent asset.
-   public String previousField        = "";
-   public String previousMultiplicity = "";
-   public String asset                = ""; // Asset according to association
-   public String cast                 = ""; // What the asset must be cast to,
-                                            // used at the users discretion
-                                            // using typeof operator.
-   public String field                = "";
-   public String multiplicity         = "";
+   public String    previousAsset        = ""; // Previous asset according to
+                                               // the
+                                               // association
+   public String    previousCast         = ""; // What the previous asset must
+                                               // be
+                                               // cast as to be valid. Used
+                                               // whenever an asset extends some
+                                               // other asset, but the
+                                               // association
+                                               // is made with the parent asset.
+   public String    previousField        = "";
+   public String    previousMultiplicity = "";
+   public String    asset                = ""; // Asset according to association
+   public String    cast                 = ""; // What the asset must be cast
+                                               // to,
+                                               // used at the users discretion
+                                               // using typeof operator.
+   public String    field                = "";
+   public String    multiplicity         = "";
+
+   public DebugInfo debug;
 
    public Connection() {
    }

--- a/src/main/java/se/kth/mal/steps/DebugInfo.java
+++ b/src/main/java/se/kth/mal/steps/DebugInfo.java
@@ -16,8 +16,6 @@ public class DebugInfo {
    }
 
    public void print() {
-      System.err.printf("Raw string '%s'\n", raw);
-      System.err.printf("  Start: Ln %s, Col %s\n", startLine, startChar);
-      System.err.printf("  End: Ln %s, Col %s\n", endLine, endChar);
+      System.err.printf("Line %s:%s to %s:%s, raw str '%s'\n", startLine, startChar, endLine, endChar, raw);
    }
 }

--- a/src/main/java/se/kth/mal/steps/DebugInfo.java
+++ b/src/main/java/se/kth/mal/steps/DebugInfo.java
@@ -1,0 +1,23 @@
+package se.kth.mal.steps;
+
+public class DebugInfo {
+   public int    startLine;
+   public int    startChar;
+   public int    endLine;
+   public int    endChar;
+   public String raw;
+
+   public DebugInfo(String raw, int startLine, int startChar, int endLine, int endChar) {
+      this.raw = raw;
+      this.startLine = startLine;
+      this.startChar = startChar;
+      this.endLine = endLine;
+      this.endChar = endChar;
+   }
+
+   public void print() {
+      System.err.printf("Raw string '%s'\n", raw);
+      System.err.printf("  Start: Ln %s, Col %s\n", startLine, startChar);
+      System.err.printf("  End: Ln %s, Col %s\n", endLine, endChar);
+   }
+}

--- a/src/main/java/se/kth/mal/steps/RecursiveConnection.java
+++ b/src/main/java/se/kth/mal/steps/RecursiveConnection.java
@@ -1,0 +1,45 @@
+package se.kth.mal.steps;
+
+import java.io.PrintWriter;
+
+import org.apache.commons.lang.RandomStringUtils;
+
+public class RecursiveConnection extends Connection {
+
+   public RecursiveConnection(String field) {
+      super(field);
+   }
+
+   @Override
+   public String print(PrintWriter writer, String prefix, String suffix) {
+      // Print occurs inside a function so we have to simulate something
+      // recursive
+      String set = decapitalize(asset) + "_" + RandomStringUtils.randomAlphabetic(5);
+      String pool = decapitalize(asset) + "_" + RandomStringUtils.randomAlphabetic(5);
+      String item = decapitalize(asset) + "_" + RandomStringUtils.randomAlphabetic(5);
+      writer.printf("Set<%s> %s = new HashSet<>();\n", asset, set);
+      writer.printf("List<%s> %s = new ArrayList<>();\n", asset, pool);
+      // Add ourselves to the returned set and current pool
+      writer.printf("%s.add(%s);\n", set, prefix.substring(0, prefix.length() - 1));
+      writer.printf("%s.add(%s);\n", pool, prefix.substring(0, prefix.length() - 1));
+
+      writer.printf("%s %s;\n", asset, item);
+      writer.printf("while(!%s.isEmpty()) {\n", pool);
+      writer.printf("%s = %s.remove(0);\n", item, pool);
+      if (isSet()) {
+         writer.printf("%s.addAll(%s.%s);\n", set, item, field + suffix);
+         writer.printf("%s.addAll(%s.%s);\n", pool, item, field + suffix);
+      }
+      else {
+         writer.printf("%s.add(%s.%s);\n", set, item, field + suffix);
+         writer.printf("%s.add(%s.%s);\n", pool, item, field + suffix);
+      }
+      writer.println("}");
+
+      // Iterate the constructed set
+      String iterator = decapitalize(asset) + "_" + RandomStringUtils.randomAlphabetic(5);
+      writer.printf("for (%s %s : %s) {\n", asset, iterator, set);
+      prefix = iterator + ".";
+      return prefix;
+   }
+}

--- a/src/main/java/se/kth/mal/steps/RecursiveConnection.java
+++ b/src/main/java/se/kth/mal/steps/RecursiveConnection.java
@@ -42,4 +42,9 @@ public class RecursiveConnection extends Connection {
       prefix = iterator + ".";
       return prefix;
    }
+
+   @Override
+   public String illustrate() {
+      return field + "+";
+   }
 }

--- a/src/main/java/se/kth/mal/steps/SelectConnection.java
+++ b/src/main/java/se/kth/mal/steps/SelectConnection.java
@@ -24,9 +24,6 @@ public class SelectConnection extends Connection {
 
    @Override
    public Connection reverse() {
-      // Reversing a set operation
-      // foxtrot.(alpha.bravo \/ charlie.bravo).delta.compromise
-      // delta.
       SelectConnection connection = new SelectConnection();
       connection.previousAsset = this.asset;
       connection.previousCast = this.cast;

--- a/src/main/java/se/kth/mal/steps/SelectConnection.java
+++ b/src/main/java/se/kth/mal/steps/SelectConnection.java
@@ -24,6 +24,9 @@ public class SelectConnection extends Connection {
 
    @Override
    public Connection reverse() {
+      // Reversing a set operation
+      // foxtrot.(alpha.bravo \/ charlie.bravo).delta.compromise
+      // delta.
       SelectConnection connection = new SelectConnection();
       connection.previousAsset = this.asset;
       connection.previousCast = this.cast;
@@ -70,5 +73,17 @@ public class SelectConnection extends Connection {
          prefix = decapitalize(asset) + ".";
       }
       return prefix;
+   }
+
+   @Override
+   public String illustrate() {
+      String str = "(";
+      for (int i = 0; i < steps.size(); i++) {
+         str += steps.get(i).illustrate();
+         if (i < operators.size()) {
+            str += " " + operators.get(i) + " ";
+         }
+      }
+      return str + ")";
    }
 }

--- a/src/main/java/se/kth/mal/steps/SelectConnection.java
+++ b/src/main/java/se/kth/mal/steps/SelectConnection.java
@@ -47,7 +47,7 @@ public class SelectConnection extends Connection {
       for (Step step : steps) {
          String set = decapitalize(asset) + "_" + RandomStringUtils.randomAlphabetic(5);
          writer.printf("Set<%s> %s = new HashSet<>();\n", asset, set);
-         step.print(writer, set + ".add(%s);\n", setSuffix, false);
+         step.print(writer, set + ".add(%s);\n", prefix, setSuffix, false);
          sets.add(set);
       }
 

--- a/src/main/java/se/kth/mal/steps/Step.java
+++ b/src/main/java/se/kth/mal/steps/Step.java
@@ -13,6 +13,7 @@ public class Step {
    public String           from;
    public List<Connection> connections = new ArrayList<>();
    public String           to;
+   public DebugInfo        debug;
 
    public Step(String asset, String from, String to) {
       this.asset = asset;

--- a/src/main/java/se/kth/mal/steps/Step.java
+++ b/src/main/java/se/kth/mal/steps/Step.java
@@ -56,12 +56,41 @@ public class Step {
     * @return Reversed step
     */
    public Step reverse(String asset) {
+      // Reversing is normally trivial since connections contain fields and
+      // assets that an association has. However, when reversing set operations
+      // we must be careful. As an example, consider;
+      // Echo
+      // | compromise
+      // -> alpha.(charlie.bravo /\ delta.bravo).delta.compromise
+      // Reversing the chain literally (and incorrectly) would yield;
+      // -> delta.(bravo.charlie /\ bravo.delta).alpha
+      // Set operators must have the same type on all operands. Therefore a
+      // simple fix is to swap the step before (if any) with the last steps
+      // inside the set operation;
+      // -> delta.bravo.(charlie.alpha /\ delta.alpha)
+      // The final result require the final fields asset to be the main asset,
+      // aswell as having the previously main asset be the final asset,
+      // resulting in the final expression;
+      // Delta
+      // | compromise
+      // -> bravo.(charlie.alpha /\ delta.alpha).echo.compromise
       Step step = new Step(asset, to, from);
       for (Connection connection : connections) {
          step.connections.add(0, connection.reverse());
       }
       return step;
 
+   }
+
+   public String illustrate() {
+      String str = "";
+      for (int i = 0; i < connections.size(); i++) {
+         str += connections.get(i).illustrate();
+         if (i != connections.size() - 1) {
+            str += ".";
+         }
+      }
+      return str;
    }
 
    /**

--- a/src/main/java/se/kth/mal/steps/Step.java
+++ b/src/main/java/se/kth/mal/steps/Step.java
@@ -100,8 +100,11 @@ public class Step {
     *           final prefix. True if not.
     */
    public void print(PrintWriter writer, String format, String suffix, boolean endStep) {
+      print(writer, format, "", suffix, endStep);
+   }
+
+   public void print(PrintWriter writer, String format, String prefix, String suffix, boolean endStep) {
       int close = printCast(writer);
-      String prefix = "";
       for (Connection connection : connections) {
          prefix = connection.print(writer, prefix, suffix);
          close += (connection.cast.isEmpty() ? 1 : 2);


### PR DESCRIPTION
This request brings three new features,

**Transitive operator**
```
alpha.subAlpha+.compromise
```
With a plus sign like the example above, you describe to reach`alpha.compromise`, `alpha.subAlpha.compromise`, `alpha.subAlpha.subAlpha.compromise` and so on... until no further connection exists.

**Set operation shortening**
It is now possible to have set operations after other steps
```
alpha.(bravo /\ bravo.subBravo).compromise
```
This would expand to `(alpha.bravo /\ alpha.bravo.subBravo).compromise`

**Variables**
Within reached attack steps you may now declare local variables.
```
| compromise
  -> let MYVAR = echo.compromise,
     alpha.MYVAR
```
The resulting and only reached step would be `alpha.echo.compromise`. Variables are declared as `let [NAME] = [ANY]`, separated by comma like attack steps and are simply string replaced.